### PR TITLE
Documentation enhancement for carla-setup, carla-setup/examples and ego-vehicle

### DIFF
--- a/carla-setup/README.md
+++ b/carla-setup/README.md
@@ -22,6 +22,7 @@ pip install --user rust-just
 #### Setting up Prebuilt-MPR
 
 Run the following to set up the APT repository on your system:
+
 ```bash
 wget -qO - 'https://proget.makedeb.org/debian-feeds/prebuilt-mpr.pub' | gpg --dearmor | sudo tee /usr/share/keyrings/prebuilt-mpr-archive-keyring.gpg 1> /dev/null
 echo "deb [arch=all,$(dpkg --print-architecture) signed-by=/usr/share/keyrings/prebuilt-mpr-archive-keyring.gpg] https://proget.makedeb.org prebuilt-mpr $(lsb_release -cs)" | sudo tee /etc/apt/sources.list.d/prebuilt-mpr.list
@@ -29,6 +30,7 @@ sudo apt update
 ```
 
 #### Install just using apt
+
 ```bash
 sudo apt install just
 ```
@@ -36,6 +38,8 @@ sudo apt install just
 ## Set Up Environment
 
 ### CARLA Simulator
+
+CARLA Setup and Build processes are automated using 'just' scripts. After installing the 'just' tool, running the 'just' command in the terminal displays its context help showing the available recipes and their descriptions, as can be seen next:
 
 ```bash
 $ just
@@ -106,6 +110,18 @@ just install-server
 just server-windowed
 ```
 
+or
+
+```bash
+just server-offscreen
+```
+
+or
+
+```bash
+just server-nvidia
+```
+
 ### CARLA Client
 
 #### Install
@@ -122,22 +138,37 @@ just server-offscreen
 
 #### Test (Terminal #2)
 
+Starts *autonomous vehicle control system* for CARLA simulation with Zenoh messaging integration.  (refer to [automatic_control_zenoh.py](./examples/README.md#automatic_control_zenohpy) documentation for more details)
+
 ```bash
 just run-automatic
 ```
 
+or
+
+Starts *manual vehicle control interface* for CARLA simulation with Zenoh messaging integration. (refer to [manual_control_zenoh.py](./examples/README.md#manual_control_zenohpy) documentation for more details)
+
+```bash
+just run-manual
+```
+
 ### CARLA Build
 
-# Build CARLA API (C++)
+CARLA org provides APIs for C++ and Python, and in order to have a Rust, C++ bindings is used.
+In order to Carla API for Rust you first needs to build C++ API and then make the bindings for Rust.
+
+#### Build CARLA API (C++)
 
 ```bash
 just build-libcarla
 ```
-Built files will be available at 'carla-setup/localBuild' folder
 
-# Build CARLA API (Rust)
+Built files will be available at 'carla-setup/localBuild' folder.
+
+#### Make CARLA API (Rust)
 
 ```bash
 just make-carla
 ```
-Built files will be available at 'carla-setup/localBuild' folder
+
+Built files will be available at 'carla-setup/localBuild' folder.

--- a/carla-setup/examples/README.md
+++ b/carla-setup/examples/README.md
@@ -1,0 +1,31 @@
+# Python scripts using CARLA Client API
+
+## zenoh_vehicle.py
+
+A **utility class library** for vehicle control abstraction and integration:
+
+- CarlaUtils: Provides helper functions for clamping vehicle control values (throttle, steering, brake)
+- ZenohVehicle: A wrapper class that bridges PID control with CARLA vehicle commands
+- Zenoh integration: Subscribes to actuation commands and publishes vehicle status (brake, speed)
+- Control conversion: Converts single actuation value (-1.0 to 1.0) into separate throttle/brake commands
+- Library component: Designed to be imported and used by other vehicle control applications
+
+## automatic_control_zenoh.py
+
+An **autonomous vehicle control system** identical to the previous version:
+
+- AI agents: Implements autonomous driving with Basic, Behavior, and Constant Velocity agents
+- Zenoh publishing: Publishes vehicle speed data to `ego_vehicle/speed` topic
+- Path planning: Automatically navigates between random destinations
+- Loop mode: Continuously sets new targets after reaching destinations
+- Fully autonomous: No manual input required
+
+## manual_control_zenoh.py
+
+A **manual vehicle control interface** identical to the previous version:
+
+- Interactive control: Keyboard/mouse control using pygame (WASD keys)
+- Zenoh publishing: Publishes manual control inputs (throttle, steering, brake) to Zenoh topics
+- Zenoh subscribing: Listens for cruise control engagement commands
+- Visual interface: Provides HUD with telemetry, camera views, and sensor data
+- Manual driving: Human operator directly controls the ego vehicle

--- a/ego-vehicle/uprotocol-control/README.md
+++ b/ego-vehicle/uprotocol-control/README.md
@@ -36,6 +36,7 @@ A Rust-based ego vehicle controller for CARLA simulation that uses both uProtoco
 
 - CARLA simulator running
 - Rust toolchain installed
+- Rust API (crate) built locally (refer to [CARLA Build](./../../carla-setup/README.md#carla-build) section at carla-setup/README.md)
 - Zenoh router (optional, for distributed setup)
 - uProtocol-compatible systems for automotive integration
 

--- a/ego-vehicle/zenoh-control/README.md
+++ b/ego-vehicle/zenoh-control/README.md
@@ -35,6 +35,7 @@ A Rust-based ego vehicle controller for CARLA simulation that uses Zenoh for dis
 
 - CARLA simulator running
 - Rust toolchain installed
+- Rust API (crate) built locally (refer to [CARLA Build](./../../carla-setup/README.md#carla-build) section at carla-setup/README.md)
 - Zenoh router (optional, for distributed setup)
 
 ### Command Line Arguments


### PR DESCRIPTION
- Improving carla-setup documentation
- Adding information about the local carla crate dependency for 'ego-vehicle/uprotocol-control' and 'ego-vehicle/zenoh-control' apps
- Adding documentation for the python examples made available at carla-setup/examples