### PR TITLE
feat: add collision sensor role name

### DIFF
--- a/carla-setup/examples/manual_control_sensors.py
+++ b/carla-setup/examples/manual_control_sensors.py
@@ -926,13 +926,15 @@ class HelpText(object):
 
 
 class CollisionSensor(object):
-    def __init__(self, parent_actor, hud):
+    def __init__(self, parent_actor, hud, name="collision_1"):
         self.sensor = None
         self.history = []
         self._parent = parent_actor
         self.hud = hud
         world = self._parent.get_world()
         bp = world.get_blueprint_library().find('sensor.other.collision')
+        if bp.has_attribute('role_name'):
+            bp.set_attribute('role_name', name)
         self.sensor = world.spawn_actor(bp, carla.Transform(), attach_to=self._parent)
         # We need to pass the lambda a weak reference to self to avoid circular
         # reference.


### PR DESCRIPTION
Allows for finding the collision sensor via the CARLA API, hooking into and listening on it.