### PR TITLE
Enabling manual drive for 'manual-control-zenoh.py' script

### DIFF
--- a/carla-setup/examples/manual_control_zenoh.py
+++ b/carla-setup/examples/manual_control_zenoh.py
@@ -626,7 +626,9 @@ class KeyboardControl(object):
                     self._lights = current_lights
                     world.player.set_light_state(carla.VehicleLightState(self._lights))
                 # Apply control
-                if self._ackermann_enabled:
+                if not self._ackermann_enabled:
+                    world.player.apply_control(self._control)
+                else:
                     world.player.apply_ackermann_control(self._ackermann_control)
                     # Update control to the last one applied by the ackermann controller.
                     self._control = world.player.get_control()


### PR DESCRIPTION
@PLeVasseur has identified that our 'manual_control_zenoh.py' was different from the original 'manula_control.py' from CARLA org in a specific point that was preventing us to manually drive during its usage, in that sense I'm opening this PR in order to fix that.

I managed to do some **minimal test** due the performance issues I'm facing using the remote PC's but for both cases it seemed to work nicely, manual drive the car when the cruise control is disable and integrated with our cruise control enable using ego-vehicle and the pid_controller units as well.

I believe that more tests could be done, so I'm leaving the PR open for you to decide whether merging it or not.